### PR TITLE
Fix duplicate article aliases insertion

### DIFF
--- a/libraries/matware/jupgrade/category.php
+++ b/libraries/matware/jupgrade/category.php
@@ -175,7 +175,7 @@ class JUpgradeproCategory extends JUpgradepro
 		}
 
 		// Check if has duplicated aliases
-		$alias = $this->getAlias('#__categories', $row['alias']);
+		$alias = $this->getAlias('#__categories', $row['alias'], $row['extension']);
 
 		// Prevent MySQL duplicate error
 		// @@ Duplicate entry for key 'idx_client_id_parent_id_alias_language'

--- a/libraries/matware/jupgrade/schemas/1.5/contents.php
+++ b/libraries/matware/jupgrade/schemas/1.5/contents.php
@@ -179,8 +179,8 @@ class JUpgradeproContent extends JUpgradepro
 			// @@ Duplicate entry for key 'idx_client_id_parent_id_alias_language'
 			if ($content->load(array('alias' => $row['alias'], 'catid' => $row['catid'])))
 			{
-				// Getting the duplicated alias
-				$alias = $this->getAlias('#__content', $row['alias']);
+				$content->reset();
+				$content->id = 0;
 				// Set the modified alias
 				$row['alias'] .= "-".rand(0, 99999999);
 			}


### PR DESCRIPTION
When duplicate alias is found, first article that has this alias (already in db) gets updated instead of new article inserted. This happens as $content->bind does not update id and since id from $content->load is used. You need to reset table first and set its id to 0.
